### PR TITLE
Changed tar extraction to use system utility

### DIFF
--- a/src/Factoriod.Fetcher/Factoriod.Fetcher.csproj
+++ b/src/Factoriod.Fetcher/Factoriod.Fetcher.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.32.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Factoriod.Fetcher/Program.cs
+++ b/src/Factoriod.Fetcher/Program.cs
@@ -26,32 +26,8 @@ namespace Factoriod.Fetcher
             outputDirectory.Create();
             Console.WriteLine($"Downloading {version} to {downloadsDirectory}");
             var releaseFetcher = new ReleaseFetcher(client);
-            var outputFile = await releaseFetcher.DownloadToAsync(version, Distro.Linux64, downloadsDirectory);
-            Console.WriteLine($"Downloaded to {outputFile}");
-
-            if (outputFile.Directory == null)
-            {
-                Console.WriteLine($"Could not find directory of {outputFile}");
-                return;
-            }
-
-            var extractedFiles = Extract(outputFile, outputFile.Directory);
-            Console.WriteLine($"Extracted to {extractedFiles}");
-        }
-
-        private static DirectoryInfo Extract(FileInfo input, DirectoryInfo output)
-        {
-            Console.WriteLine($"Extracting {input} to {output}");
-            output.Create();
-            using var inputStream = input.OpenRead();
-            using var reader = ReaderFactory.Open(inputStream);
-            reader.WriteAllToDirectory(output.FullName, new ExtractionOptions
-            {
-                ExtractFullPath = true,
-                Overwrite = true
-            });
-
-            return new DirectoryInfo(Path.Join(output.FullName, "factorio"));
+            var extractedDirectory = await releaseFetcher.DownloadToAsync(version, Distro.Linux64, downloadsDirectory);
+            Console.WriteLine($"Downloaded and extracted to {extractedDirectory}");
         }
     }
 }

--- a/src/Factoriod.Fetcher/Program.cs
+++ b/src/Factoriod.Fetcher/Program.cs
@@ -2,8 +2,6 @@
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
-using SharpCompress.Common;
-using SharpCompress.Readers;
 
 namespace Factoriod.Fetcher
 {

--- a/src/Factoriod.Fetcher/ReleaseFetcher.cs
+++ b/src/Factoriod.Fetcher/ReleaseFetcher.cs
@@ -71,11 +71,11 @@ namespace Factoriod.Fetcher
             }
 
             await tarProcess.WaitForExitAsync(cancellationToken);
-            Console.WriteLine($"stdout:\n{tarProcess.StandardOutput.ReadToEnd()}");
-            Console.WriteLine($"stderr:\n{tarProcess.StandardError.ReadToEnd()}");
             if (tarProcess.ExitCode != 0)
             {
                 Console.WriteLine($"Tar process exited with code {tarProcess.ExitCode}");
+                Console.WriteLine($"stdout:\n{tarProcess.StandardOutput.ReadToEnd()}");
+                Console.WriteLine($"stderr:\n{tarProcess.StandardError.ReadToEnd()}");
                 return null;
             }
 


### PR DESCRIPTION
SharpCompress does not retain file permissions when extracting tar archives. There's a flag you can pass it, but it throws a `System.NotImplementedException`