### PR TITLE
Changed build output to framework-dependent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,10 @@
 name: Release
 
-
 on:
   workflow_dispatch:
   release:
     types:
       - published
-    
     
 jobs:
   build:
@@ -26,4 +24,4 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: factoriod-deb
-        path: src/Factoriod.Daemon/bin/Release/net6.0/linux-x64/factoriod.*.deb
+        path: src/Factoriod.Daemon/bin/Release/net6.0/factoriod.*.deb

--- a/src/Factoriod.Daemon/Factoriod.Daemon.csproj
+++ b/src/Factoriod.Daemon/Factoriod.Daemon.csproj
@@ -19,6 +19,12 @@
 
   <PropertyGroup>
     <PackagePrefix>factoriod</PackagePrefix>
+    <Prefix>/usr/local/lib/factoriod</Prefix>
+
+    <DebSection>games</DebSection>
+    <DebPriority>optional</DebPriority>
+    <DebPackageArchitecture>amd64</DebPackageArchitecture>
+
     <CreateUser>true</CreateUser>
     <UserName>factorio</UserName>
 

--- a/src/Factoriod.Daemon/Factoriod.Daemon.csproj
+++ b/src/Factoriod.Daemon/Factoriod.Daemon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>factoriod</PackageId>
-    <Version>0.1.3</Version>
+    <Version>0.1.4</Version>
     <Authors>asasine</Authors>
     <Company>asasine</Company>
     <Description>A factorio daemon for Ubuntu</Description>

--- a/src/Factoriod.Daemon/Factoriod.Daemon.csproj
+++ b/src/Factoriod.Daemon/Factoriod.Daemon.csproj
@@ -18,12 +18,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <PackagePrefix>factoriod</PackagePrefix>
     <CreateUser>true</CreateUser>
     <UserName>factorio</UserName>

--- a/src/Factoriod.Fetcher/Factoriod.Fetcher.csproj
+++ b/src/Factoriod.Fetcher/Factoriod.Fetcher.csproj
@@ -5,15 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>true</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-  </PropertyGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />


### PR DESCRIPTION
Ubuntu 22 has the .NET 6 runtime available in official package sources, therefore framework-dependent packages is no longer necessary.